### PR TITLE
add gtk-4-rs-docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,12 @@
+name: CI
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches: [main]
 jobs:
-  lint:
+  Awesome_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm install --global awesome-lint
-      - run: awesome-lint
+      - run: npx awesome-lint

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Although the AppImage format was carefully designed not to need any special supp
 ### Deployment tools for Rust applications
 
 - [Cargo AppImage](https://github.com/StratusFearMe21/cargo-appimage) - Cargo program that allows you to convert your Rust programs into AppImages.
-- [gtk-4-rs-docker](https://github.com/13hannes11/gtk4-rs-docker/blob/main/appimage/Dockerfile) - Docker build system, which can create AppImage for your Rust + GTK4 application
+- [gtk-4-rs-docker](https://github.com/13hannes11/gtk4-rs-docker/blob/main/appimage/Dockerfile) - Docker build system, which can create AppImage for your Rust + GTK4 application.
 
 ### Tools to convert from other package formats
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Although the AppImage format was carefully designed not to need any special supp
 ### Deployment tools for Rust applications
 
 - [Cargo AppImage](https://github.com/StratusFearMe21/cargo-appimage) - Cargo program that allows you to convert your Rust programs into AppImages.
+- [gtk-4-rs-docker](https://github.com/13hannes11/gtk4-rs-docker/blob/main/appimage/Dockerfile) - Docker build system, which can create AppImage for your Rust + GTK4 application
 
 ### Tools to convert from other package formats
 


### PR DESCRIPTION
I noticed that gtk4 + rust is a [popular](https://github.com/valpackett/awesome-gtk/) [boilerplate](https://gitlab.gnome.org/World/Rust/gtk-rust-template) for building apps, so it will be cool if we add this packaging tool