### PR TITLE
Update README.md with link to XojoToAppImage project

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 ### App catalogs
 
 - [AppImage.GitHub.io](https://appimage.github.io/) - Catalog of AppImages that passed an automated test, links to upstream download pages.
-- [Get AppImage](https://g.srev.in/get-appimage/) - Collection of all AppImages in one website. Great search functionality.
+- [Get AppImage](https://g.sreve/get-appimage/) - Collection of all AppImages in one website. Great search functionality.
 
 ### App stores
 
@@ -161,7 +161,7 @@ Although the AppImage format was carefully designed not to need any special supp
 - [go-appimagetool](https://github.com/probonopd/go-appimage/tree/master/src/appimagetool) - Tool that deploys dependencies into AppDirs, and converts AppDirs into AppImages (experimental).
 - [linuxdeployqt](https://github.com/probonopd/linuxdeployqt) - Deploys dependencies into AppDirs and creates AppImages; for Qt and other compiled applications.
 - [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) - AppDir creation and maintenance tool using plugins.
-- [XojoToAppImage](https://github.com/AlwaysOfflineSoftware/XojoToAppImage) - Gui tool for packaging compiled Xojo Linux programs into AppImages.
+- [XojoToAppImage](https://github.com/AlwaysOfflineSoftware/XojoToAppImage) - Graphical tool for packaging compiled Xojo Linux programs into AppImages.
 
 ### Deployment tools for Python applications
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Although the AppImage format was carefully designed not to need any special supp
 - [go-appimagetool](https://github.com/probonopd/go-appimage/tree/master/src/appimagetool) - Tool that deploys dependencies into AppDirs, and converts AppDirs into AppImages (experimental).
 - [linuxdeployqt](https://github.com/probonopd/linuxdeployqt) - Deploys dependencies into AppDirs and creates AppImages; for Qt and other compiled applications.
 - [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) - AppDir creation and maintenance tool using plugins.
+- [XojoToAppImage](https://github.com/AlwaysOfflineSoftware/XojoToAppImage) - Gui tool for packaging compiled Xojo Linux programs into AppImages.
 
 ### Deployment tools for Python applications
 


### PR DESCRIPTION
Added XojoToAppImage tool link to the compiled applications section of the README document.
Project found here: [XojoToAppImage](https://github.com/AlwaysOfflineSoftware/XojoToAppImage)